### PR TITLE
Add a new locale: Spanish and Guaraní (Paraguay) to locales.php

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -933,6 +933,17 @@ class GP_Locales {
 		$es_pa->google_code = 'es';
 		$es_pa->facebook_locale = 'es_LA';
 
+		$es_py = new GP_Locale();
+		$es_py->english_name = 'Spanish (Paraguay)';
+		$es_py->native_name = 'Español de Paraguay';
+		$es_py->lang_code_iso_639_1 = 'es';
+		$es_py->lang_code_iso_639_2 = 'spa';
+		$es_py->lang_code_iso_639_3 = 'spa';
+		$es_py->country_code = 'py';
+		$es_py->slug = 'es-py';
+		$es_py->google_code = 'es';
+		$es_py->facebook_locale = 'es_LA';
+
 		$es_pe = new GP_Locale();
 		$es_pe->english_name = 'Spanish (Peru)';
 		$es_pe->native_name = 'Español de Perú';
@@ -1225,6 +1236,15 @@ class GP_Locales {
 		$gn->lang_code_iso_639_1 = 'gn';
 		$gn->lang_code_iso_639_2 = 'grn';
 		$gn->slug = 'gn';
+
+		$gn_py = new GP_Locale();
+		$gn_py->english_name = 'Guaraní (Paraguay)';
+		$gn_py->native_name = 'Avañe\'ẽ';
+		$gn_py->lang_code_iso_639_1 = 'gn';
+		$gn_py->lang_code_iso_639_2 = 'grn';
+		$gn_py->lang_code_iso_639_3 = 'grn';
+		$gn_py->country_code = 'py';
+		$gn_py->slug = 'gn-py';
 
 		$gsw = new GP_Locale();
 		$gsw->english_name = 'Swiss German';


### PR DESCRIPTION
**Overview**  
This pull request seeks to add new locales for Spanish (Paraguay) (`es-py`) and Guaraní (Paraguay) (`gn-py`) to WordPress. This initiative aims to reopen and continue the discussion from the previously initiated issue: [Request for Paraguayan Spanish and Guaraní Locales](https://make.wordpress.org/polyglots/2019/10/28/request-a-locale-paraguayan-spanish/).

**Rationale**  
The inclusion of these locales is critical for addressing the unique linguistic preferences and cultural nuances of the Paraguayan WordPress community. These locales will provide more accurate and region-specific language support, significantly enhancing the user experience for WordPress users in Paraguay by catering to regional variations in vocabulary, syntax, and semantics.

**Problem Statement**  
- The current WordPress platform lacks specific locales for Paraguayan Spanish and Guaraní, which limits the platform's accessibility and relevance to users in Paraguay.

**Proposed Solution**  
- Introduce two new locales: Spanish (Paraguay) and Guaraní (Paraguay), with the respective language codes and country-specific adaptations.
